### PR TITLE
docs: add Firestore rules example

### DIFF
--- a/FIREBASE_SETUP.md
+++ b/FIREBASE_SETUP.md
@@ -22,7 +22,7 @@
 
 ### 3. Configurer les règles de sécurité Firestore
 1. Dans Firestore Database, allez dans l'onglet "Règles"
-2. Remplacez les règles par défaut par :
+2. Copiez le contenu du fichier [`firestore.rules`](./firestore.rules) et remplacez les règles par défaut :
 
 ```javascript
 rules_version = '2';

--- a/SETUP_INSTRUCTIONS.md
+++ b/SETUP_INSTRUCTIONS.md
@@ -34,7 +34,7 @@ NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID=G-NZB9NZ3TNM
 
 ## 🔒 Étape 3 : Configurer les règles de sécurité
 
-Dans Firestore Database > Règles, remplacez les règles par :
+Dans Firestore Database > Règles, remplacez les règles par le contenu du fichier [`firestore.rules`](./firestore.rules) :
 
 ```javascript
 rules_version = '2';

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,9 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    // Permettre la lecture et l'écriture pour la collection RSVP
+    match /rsvp/{document} {
+      allow read, write: if true;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add Firestore security rules example file
- link Firestore rules file from Firebase setup docs

## Testing
- `yarn lint` *(fails: package not in lockfile)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689db18f70bc833087ff8bad3476e397