### PR TITLE
refactor: split client components

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,16 +1,9 @@
-"use client";
 import Image from "next/image";
-import { useEffect, useState } from "react";
-import React from "react";
-import RSVPForm from "@/components/RSVPForm";
+import dynamic from "next/dynamic";
+import Section from "@/components/Section";
 
-function Section({ children, className = "" }: React.PropsWithChildren<{ className?: string }>) {
-  return (
-    <section className={`w-full max-w-5xl mx-auto py-12 px-4 ${className}`}>
-      {children}
-    </section>
-  );
-}
+const Carousel = dynamic(() => import("@/components/Carousel"), { ssr: false });
+const RSVPForm = dynamic(() => import("@/components/RSVPForm"), { ssr: false });
 
 function getCountdown() {
   const weddingDate = new Date("2025-10-11T10:00:00+02:00").getTime();
@@ -25,19 +18,15 @@ function getCountdown() {
 }
 
 export default function Home() {
-  const [countdown, setCountdown] = useState(getCountdown());
-
-  useEffect(() => {
-    const timer = setInterval(() => {
-      setCountdown(getCountdown());
-    }, 1000);
-    return () => clearInterval(timer);
-  }, []);
+  const countdown = getCountdown();
 
   return (
     <main className="flex flex-col items-center w-full min-h-screen bg-[#f8f6f2]">
       {/* HERO avec image de fond, titre, compte à rebours */}
-      <div className="relative w-full h-screen flex items-center justify-center bg-cover bg-center" style={{backgroundImage: "url('/couple.jpg')"}}>
+      <div
+        className="relative w-full h-screen flex items-center justify-center bg-cover bg-center"
+        style={{ backgroundImage: "url('/couple.jpg')" }}
+      >
         <div className="absolute inset-0 bg-black/40" />
         <div className="relative z-10 flex flex-col items-center text-white text-center">
           <h2 className="text-lg tracking-widest mb-2">SAVE THE DATE</h2>
@@ -46,6 +35,9 @@ export default function Home() {
           {countdown ? (
             <div className="flex gap-4 text-2xl font-mono justify-center">
               <span>{countdown.days} jours</span>
+              <span>{countdown.hours} h</span>
+              <span>{countdown.minutes} min</span>
+              <span>{countdown.seconds} s</span>
             </div>
           ) : (
             <div className="text-2xl font-semibold mt-4">C&apos;est le grand jour !</div>
@@ -158,167 +150,5 @@ export default function Home() {
         </div>
       </Section>
     </main>
-  );
-}
-
-// Carrousel type Stories Instagram (à placer en bas du fichier)
-  function Carousel() {
-    const media = React.useMemo(
-      () => [
-        "/couple1.jpg",
-        "/couple2.jpg",
-        "/couple3.jpg",
-        "/couple4.jpg",
-        "/couple5.jpg",
-        "/couple6.jpg",
-        "/couple7.jpg",
-        "/couple8.jpg",
-        "/couple9.jpg",
-        "/couple10.jpg",
-        "/couple11.jpg",
-        "/couple12.jpg",
-        "/couple13.jpg",
-        "/couple14.jpg",
-        "/reel1.mp4",
-        "/couple15.jpg",
-      ],
-      []
-    );
-  
-  const [index, setIndex] = React.useState(0);
-  const [isPaused, setIsPaused] = React.useState(false);
-  const [progress, setProgress] = React.useState(0);
-  const STORY_DURATION = 3000; // 3 secondes par story
-  
-  // Timer pour la progression en temps réel
-    React.useEffect(() => {
-      if (isPaused) return;
-    
-    // Pour les vidéos, on ne gère pas la progression automatique
-    if (media[index].endsWith('.mp4')) {
-      setProgress(0);
-      return;
-    }
-    
-    const startTime = Date.now();
-    const interval = setInterval(() => {
-      const elapsed = Date.now() - startTime;
-      const newProgress = Math.min((elapsed / STORY_DURATION) * 100, 100);
-      setProgress(newProgress);
-      
-      if (newProgress >= 100) {
-        setIndex((i) => (i + 1) % media.length);
-        setProgress(0);
-      }
-    }, 50); // Mise à jour toutes les 50ms pour une animation fluide
-    
-    return () => clearInterval(interval);
-    }, [index, isPaused, media]);
-  
-  // Reset progress quand l'index change
-  React.useEffect(() => {
-    setProgress(0);
-  }, [index]);
-  
-  const prev = () => {
-    setIndex((i) => (i === 0 ? media.length - 1 : i - 1));
-    setProgress(0);
-  };
-  
-  const next = () => {
-    setIndex((i) => (i + 1) % media.length);
-    setProgress(0);
-  };
-  
-  const handleTouchStart = () => setIsPaused(true);
-  const handleTouchEnd = () => setIsPaused(false);
-  
-  const handleTap = (side: 'left' | 'right') => {
-    if (side === 'left') prev();
-    else next();
-  };
-  
-  return (
-    <div className="relative w-full flex flex-col items-center justify-center">
-      {/* Barres de progression */}
-      <div className="flex gap-2 w-full max-w-md mx-auto mb-4">
-        {media.map((_, i) => (
-          <div key={i} className="flex-1 h-1 rounded-full bg-gray-300/60 overflow-hidden border border-gray-400/40 shadow-sm">
-            <div
-              className={`h-full transition-all duration-300 ease-out rounded-full ${
-                i < index 
-                  ? 'bg-gradient-to-r from-gray-600 via-gray-700 to-gray-800 shadow-md progress-completed' 
-                  : i === index 
-                    ? media[i].endsWith('.mp4') 
-                      ? 'bg-gradient-to-r from-blue-500 via-blue-600 to-blue-700 shadow-md animate-pulse' 
-                      : 'bg-gradient-to-r from-gray-600 via-gray-700 to-gray-800 shadow-md'
-                    : 'bg-gray-400/30'
-              }`}
-              style={i === index ? { width: media[i].endsWith('.mp4') ? '100%' : `${progress}%` } : { width: i < index ? '100%' : '0%' }}
-            />
-          </div>
-        ))}
-      </div>
-      
-      {/* Container stories vertical iPhone */}
-      <div className="relative w-full max-w-xs sm:max-w-sm md:max-w-md lg:max-w-lg mx-auto">
-        <div 
-          className="relative w-full aspect-[9/19.5] rounded-xl overflow-hidden shadow-lg cursor-pointer"
-          onTouchStart={handleTouchStart}
-          onTouchEnd={handleTouchEnd}
-          onMouseDown={handleTouchStart}
-          onMouseUp={handleTouchEnd}
-          onMouseLeave={handleTouchEnd}
-        >
-          {media[index].endsWith('.mp4') ? (
-            <video
-              src={media[index]}
-              controls
-              autoPlay
-              muted
-              className="object-cover w-full h-full"
-              onEnded={() => {
-                setIndex((i) => (i + 1) % media.length);
-                setProgress(0);
-              }}
-              onError={() => {
-                // En cas d'erreur vidéo, passer à la suivante après 2 secondes
-                setTimeout(() => {
-                  setIndex((i) => (i + 1) % media.length);
-                  setProgress(0);
-                }, 2000);
-              }}
-            />
-          ) : (
-            <Image src={media[index]} alt={`Souvenir ${index+1}`} fill className="object-cover transition-all duration-500" />
-          )}
-          
-          {/* Zones de tap pour navigation */}
-          <div 
-            className="absolute left-0 top-0 w-1/2 h-full cursor-pointer"
-            onClick={() => handleTap('left')}
-          />
-          <div 
-            className="absolute right-0 top-0 w-1/2 h-full cursor-pointer"
-            onClick={() => handleTap('right')}
-          />
-          
-          {/* Indicateur de pause */}
-          {isPaused && (
-            <div className="absolute top-4 right-4 bg-black/50 text-white px-2 py-1 rounded text-sm">
-              ⏸️ Pause
-            </div>
-          )}
-          
-          {/* Boutons de navigation (optionnels) */}
-          <button onClick={prev} className="absolute left-2 top-1/2 -translate-y-1/2 bg-white/70 hover:bg-white rounded-full p-2 shadow text-gray-700 opacity-0 hover:opacity-100 transition-opacity">
-            &#8592;
-          </button>
-          <button onClick={next} className="absolute right-2 top-1/2 -translate-y-1/2 bg-white/70 hover:bg-white rounded-full p-2 shadow text-gray-700 opacity-0 hover:opacity-100 transition-opacity">
-            &#8594;
-          </button>
-        </div>
-      </div>
-    </div>
   );
 }

--- a/src/components/Carousel.tsx
+++ b/src/components/Carousel.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import Image from "next/image";
+import React from "react";
+
+export default function Carousel() {
+  const media = React.useMemo(
+    () => [
+      "/couple1.jpg",
+      "/couple2.jpg",
+      "/couple3.jpg",
+      "/couple4.jpg",
+      "/couple5.jpg",
+      "/couple6.jpg",
+      "/couple7.jpg",
+      "/couple8.jpg",
+      "/couple9.jpg",
+      "/couple10.jpg",
+      "/couple11.jpg",
+      "/couple12.jpg",
+      "/couple13.jpg",
+      "/couple14.jpg",
+      "/reel1.mp4",
+      "/couple15.jpg",
+    ],
+    []
+  );
+
+  const [index, setIndex] = React.useState(0);
+  const [isPaused, setIsPaused] = React.useState(false);
+  const [progress, setProgress] = React.useState(0);
+  const STORY_DURATION = 3000; // 3 secondes par story
+
+  // Timer pour la progression en temps réel
+  React.useEffect(() => {
+    if (isPaused) return;
+
+    // Pour les vidéos, on ne gère pas la progression automatique
+    if (media[index].endsWith('.mp4')) {
+      setProgress(0);
+      return;
+    }
+
+    const startTime = Date.now();
+    const interval = setInterval(() => {
+      const elapsed = Date.now() - startTime;
+      const newProgress = Math.min((elapsed / STORY_DURATION) * 100, 100);
+      setProgress(newProgress);
+
+      if (newProgress >= 100) {
+        setIndex((i) => (i + 1) % media.length);
+        setProgress(0);
+      }
+    }, 50); // Mise à jour toutes les 50ms pour une animation fluide
+
+    return () => clearInterval(interval);
+  }, [index, isPaused, media]);
+
+  // Reset progress quand l'index change
+  React.useEffect(() => {
+    setProgress(0);
+  }, [index]);
+
+  const prev = () => {
+    setIndex((i) => (i === 0 ? media.length - 1 : i - 1));
+    setProgress(0);
+  };
+
+  const next = () => {
+    setIndex((i) => (i + 1) % media.length);
+    setProgress(0);
+  };
+
+  const handleTouchStart = () => setIsPaused(true);
+  const handleTouchEnd = () => setIsPaused(false);
+
+  const handleTap = (side: 'left' | 'right') => {
+    if (side === 'left') prev();
+    else next();
+  };
+
+  return (
+    <div className="relative w-full flex flex-col items-center justify-center">
+      {/* Barres de progression */}
+      <div className="flex gap-2 w-full max-w-md mx-auto mb-4">
+        {media.map((_, i) => (
+          <div key={i} className="flex-1 h-1 rounded-full bg-gray-300/60 overflow-hidden border border-gray-400/40 shadow-sm">
+            <div
+              className={`h-full transition-all duration-300 ease-out rounded-full ${
+                i < index
+                  ? 'bg-gradient-to-r from-gray-600 via-gray-700 to-gray-800 shadow-md progress-completed'
+                  : i === index
+                    ? media[i].endsWith('.mp4')
+                      ? 'bg-gradient-to-r from-blue-500 via-blue-600 to-blue-700 shadow-md animate-pulse'
+                      : 'bg-gradient-to-r from-gray-600 via-gray-700 to-gray-800 shadow-md'
+                    : 'bg-gray-400/30'
+              }`}
+              style={i === index ? { width: media[i].endsWith('.mp4') ? '100%' : `${progress}%` } : { width: i < index ? '100%' : '0%' }}
+            />
+          </div>
+        ))}
+      </div>
+
+      {/* Container stories vertical iPhone */}
+      <div className="relative w-full max-w-xs sm:max-w-sm md:max-w-md lg:max-w-lg mx-auto">
+        <div
+          className="relative w-full aspect-[9/19.5] rounded-xl overflow-hidden shadow-lg cursor-pointer"
+          onTouchStart={handleTouchStart}
+          onTouchEnd={handleTouchEnd}
+          onMouseDown={handleTouchStart}
+          onMouseUp={handleTouchEnd}
+          onMouseLeave={handleTouchEnd}
+        >
+          {media[index].endsWith('.mp4') ? (
+            <video
+              src={media[index]}
+              controls
+              autoPlay
+              muted
+              className="object-cover w-full h-full"
+              onEnded={() => {
+                setIndex((i) => (i + 1) % media.length);
+                setProgress(0);
+              }}
+              onError={() => {
+                // En cas d'erreur vidéo, passer à la suivante après 2 secondes
+                setTimeout(() => {
+                  setIndex((i) => (i + 1) % media.length);
+                  setProgress(0);
+                }, 2000);
+              }}
+            />
+          ) : (
+            <Image src={media[index]} alt={`Souvenir ${index+1}`} fill className="object-cover transition-all duration-500" />
+          )}
+
+          {/* Zones de tap pour navigation */}
+          <div
+            className="absolute left-0 top-0 w-1/2 h-full cursor-pointer"
+            onClick={() => handleTap('left')}
+          />
+          <div
+            className="absolute right-0 top-0 w-1/2 h-full cursor-pointer"
+            onClick={() => handleTap('right')}
+          />
+
+          {/* Indicateur de pause */}
+          {isPaused && (
+            <div className="absolute top-4 right-4 bg-black/50 text-white px-2 py-1 rounded text-sm">
+              ⏸️ Pause
+            </div>
+          )}
+
+          {/* Boutons de navigation (optionnels) */}
+          <button onClick={prev} className="absolute left-2 top-1/2 -translate-y-1/2 bg-white/70 hover:bg-white rounded-full p-2 shadow text-gray-700 opacity-0 hover:opacity-100 transition-opacity">
+            &#8592;
+          </button>
+          <button onClick={next} className="absolute right-2 top-1/2 -translate-y-1/2 bg-white/70 hover:bg-white rounded-full p-2 shadow text-gray-700 opacity-0 hover:opacity-100 transition-opacity">
+            &#8594;
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Section.tsx
+++ b/src/components/Section.tsx
@@ -1,0 +1,9 @@
+import { PropsWithChildren } from "react";
+
+export default function Section({ children, className = "" }: PropsWithChildren<{ className?: string }>) {
+  return (
+    <section className={`w-full max-w-5xl mx-auto py-12 px-4 ${className}`}>
+      {children}
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- convert home page to server component that dynamically imports Carousel and RSVPForm client components
- compute countdown server-side and render static sections through a Section wrapper
- dynamically import client components to ensure they're loaded on the client only

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_689de7b5e61c8330a49c93b86907cfb6