### PR TITLE
feat: add carousel pause controls

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -27,6 +27,16 @@ function getCountdown() {
 
 export default function Home() {
   const [countdown, setCountdown] = useState(getCountdown());
+  const [isPaused, setIsPaused] = useState(false);
+
+  const handleCarouselKeyDown = (
+    e: React.KeyboardEvent<HTMLDivElement>
+  ) => {
+    if (e.key === ' ' || e.key === 'p' || e.key === 'P') {
+      e.preventDefault();
+      setIsPaused((prev) => !prev);
+    }
+  };
 
   useEffect(() => {
     const timer = setInterval(() => {
@@ -123,7 +133,21 @@ export default function Home() {
           <h2 className="text-3xl font-bold mb-2">Galerie de souvenirs</h2>
           <p className="text-lg text-gray-600">Quelques moments précieux</p>
         </div>
-        <Carousel />
+        <div
+          tabIndex={0}
+          onKeyDown={handleCarouselKeyDown}
+          className="flex flex-col items-center"
+        >
+          <Carousel isPaused={isPaused} setIsPaused={setIsPaused} />
+          <button
+            onClick={() => setIsPaused((prev) => !prev)}
+            aria-pressed={isPaused}
+            aria-label={isPaused ? 'Resume carousel' : 'Pause carousel'}
+            className="mt-4 px-4 py-2 bg-gray-700 text-white rounded"
+          >
+            {isPaused ? 'Resume' : 'Pause'}
+          </button>
+        </div>
       </Section>
 
       {/* SECTION RSVP (formulaire) */}

--- a/src/components/Carousel.tsx
+++ b/src/components/Carousel.tsx
@@ -3,7 +3,12 @@
 import React from 'react';
 import Image from 'next/image';
 
-export default function Carousel() {
+interface CarouselProps {
+  isPaused: boolean;
+  setIsPaused: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+export default function Carousel({ isPaused, setIsPaused }: CarouselProps) {
   const media = React.useMemo(
     () => [
       "/couple1.jpg",
@@ -27,7 +32,6 @@ export default function Carousel() {
   );
 
   const [index, setIndex] = React.useState(0);
-  const [isPaused, setIsPaused] = React.useState(false);
   const [progress, setProgress] = React.useState(0);
   const STORY_DURATION = 3000; // 3 secondes par story
 


### PR DESCRIPTION
## Summary
- add external pause state for carousel
- enable keyboard and button toggle of carousel playback

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689df6cc29108330866a06766fdbdc14