### PR TITLE
chore: use dynamic imports for heavy components

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,15 @@
 "use client";
 import { useEffect, useState } from "react";
 import React from "react";
-import Carousel from "@/components/Carousel";
-import RSVPForm from "@/components/RSVPForm";
+import dynamic from "next/dynamic";
+
+const Carousel = dynamic(() => import("@/components/Carousel"), {
+  loading: () => <div>Chargement...</div>,
+});
+
+const RSVPForm = dynamic(() => import("@/components/RSVPForm"), {
+  loading: () => <div>Chargement...</div>,
+});
 
 function Section({ children, className = "" }: React.PropsWithChildren<{ className?: string }>) {
   return (


### PR DESCRIPTION
## Summary
- dynamically import Carousel and RSVPForm to defer loading heavy components
- add loading fallbacks for both components

## Testing
- `npm test` *(fails: missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a59443e02c8330ab6675a45a678100