### PR TITLE
chore: reduce video preload

### DIFF
--- a/src/components/Carousel.tsx
+++ b/src/components/Carousel.tsx
@@ -218,6 +218,7 @@ export default function Carousel({ isPaused, setIsPaused }: CarouselProps) {
               src={media[index].src}
               controls
               autoPlay
+              preload="metadata"
               muted
               className="object-cover w-full h-full"
               onEnded={() => {


### PR DESCRIPTION
## Summary
- add `preload="metadata"` to the carousel video element

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a59d74afa4833092cc43b04cdac1a5