### PR TITLE
fix: improve hero background positioning on mobile

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -54,7 +54,10 @@ export default function Home() {
   return (
     <main className="flex flex-col items-center w-full min-h-screen bg-[#f8f6f2]">
       {/* HERO avec image de fond, titre, compte à rebours */}
-      <div className="relative w-full h-screen flex items-center justify-center bg-cover bg-center" style={{backgroundImage: "url('/couple.jpg')"}}>
+      <div
+        className="relative w-full h-screen flex items-center justify-center bg-cover bg-right md:bg-center"
+        style={{ backgroundImage: "url('/couple.jpg')" }}
+      >
         <div className="absolute inset-0 bg-black/40" />
         <div className="relative z-10 flex flex-col items-center text-white text-center">
           <h2 className="text-lg tracking-widest mb-2">SAVE THE DATE</h2>


### PR DESCRIPTION
## Summary
- ensure hero background shows right side on mobile by using `bg-right md:bg-center`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b5c87ef728833081c2ffcf972e8c7a